### PR TITLE
Fix wrong comparison causing localPort to stay "null" if not explicitly defined.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -23,7 +23,7 @@ function createConfig(userConfig) {
   }
 
   // Use the same port number local
-  if (config.localPort === undefined) {
+  if (config.localPort === null) {
     config.localPort = config.dstPort;
   }
   return config;


### PR DESCRIPTION
when running the defaults, `localPort` will bet set to `null` if it wasnt passed by the user. `null === undefined` fails, so it will stay `null`