### PR TITLE
Keepalive stuck ssh connections

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var noop = function () {
 
 function bindSSHConnection(config, netConnection) {
     var sshConnection = new Connection();
+    netConnection.on('close', sshConnection.end.bind(sshConnection));
 
     sshConnection.on('ready', function () {
         debug('sshConnection:ready');
@@ -30,11 +31,11 @@ function bindSSHConnection(config, netConnection) {
 
 function createServer(config) {
     var server;
-    var sshConnection;
     var connections = [];
     var connectionCount = 0;
 
     server = net.createServer(function (netConnection) {
+        var sshConnection;
         connectionCount++;
         netConnection.on('error', server.emit.bind(server, 'error'));
         netConnection.on('close', function () {

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,17 +34,17 @@ function createConfig(config) {
     if (!config.dstPort) {
         throw new ConfigError('dstPort not set');
     }
-    debug('ssh-config', (function(){
-        var hiddenValues = ['password','privateKey'];
+    debug('ssh-config', (function () {
+        var hiddenValues = ['password', 'privateKey'];
 
-        return Object.keys(config).reduce(function(obj, key){
-            if(hiddenValues.indexOf(key) === -1){
-            obj[key] = config[key];
-        }else{
-            obj[key] = '***HIDDEN***'
-        }
+        return Object.keys(config).reduce(function (obj, key) {
+            if (hiddenValues.indexOf(key) === -1) {
+                obj[key] = config[key];
+            } else {
+                obj[key] = '***HIDDEN***';
+            }
             return obj;
-        },{})
+        }, {});
     })());
 
     return config;


### PR DESCRIPTION
Hey! thanks for the library, has made my tunnelling life a lot easier :)

I noticed an issue when using the keepAlive setting, keeping the local server up. Over time the host I was SSHing into would see the total number of SSH connections only growing, even if connections to the local server were closed. These SSH connections weren't disconnected until I killed the local server started by tunnel-ssh.

The change still opens one SSH connection per local-server connection, so the behaviour there is unchanged - it just ends the underlying SSH connection when the local-server connection closes and stops them leaking.

I'm not sure if this affects use cases I'm unaware of at all but it seems to hold up to my various tests, and the test suite still passes (I've fixed up a few eslint errors that appeared when I ran `npm test` too in a separate commit).

Thanks again!
