### PR TITLE
Upgrade debug to 2.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "debug": "2.6.0",
+    "debug": "2.6.8",
     "lodash.defaults": "^4.1.0",
     "ssh2": "0.5.4"
   },


### PR DESCRIPTION
Currently the project depends on `debug:2.6.0` which uses `ms:0.7.2` module internally, with known [security issues](https://snyk.io/vuln/npm:ms:20151024). This is fixed in `ms:2.0.0` which is used in `debug:2.6.8`. 