### PR TITLE
Minor syntax fix in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ tunnel-ssh assumes that you want to map the same port on a remote machine to you
       username:'root',
       dstHost:'remotehost.with.sshserver.com',
       dstPort:27017,
-      privateKey:require(fs.readFileSync('/path/to/key'),
+      privateKey:require(fs).readFileSync('/path/to/key'),
       passphrase:'secret'
     };
 


### PR DESCRIPTION
With the missing paren, someone might get confused about the presence of `require` and somehow require the key file.