### PR TITLE
fix uncaught error from ssh2/lib/client#connect method

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,13 @@ function createServer(config) {
         });
 
         connections.push(sshConnection, netConnection);
-        sshConnection.connect(config);
+        try
+        {
+            sshConnection.connect(config);
+        }catch(error)
+        {
+            server.emit('error', error);
+        }
     });
 
     server.on('close', function () {


### PR DESCRIPTION
Errors in ssh2/client#connect can't be caught with neither `tunnel(callback)` or `tunnel.on('error', callback)` causing process to crash