### PR TITLE
Fixed incorrect arguments in readme for simple tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ function mySimpleTunnel(sshOptions, port, autoClose = true){
         port: port
     }
 
-    return createTunnel(tunnelOptions, serverOptions, sshOptions, autoClose);
+    return createTunnel(tunnelOptions, serverOptions, sshOptions, forwardOptions);
 }
 
 await mySimpleTunnel(sshOptions, 27017);


### PR DESCRIPTION
The readme has an incorrect final argument for the `mySimpleTunnel` function. 