### PR TITLE
fix: crash when receiving "No Response from server"

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ async function createTunnel( tunnelOptions, serverOptions, sshOptions, forwardOp
                         if (server) {
                             server.close()
                         }
-                        throw err;
+                        sshConnection.emit("error", err);
                     } else {
                         clientConnection.pipe(stream).pipe(clientConnection);
                     }


### PR DESCRIPTION
Fixes #113

Avoid throwing errors inside asynchronous callbacks. Instead, sends the error back into the published emitter.